### PR TITLE
Create activities table creation migration

### DIFF
--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -14,6 +14,7 @@ class CreateUsersTable extends Migration
     public function up()
     {
         Schema::create('users', function (Blueprint $table) {
+            $table->engine = 'InnoDB';
             $table->increments('id');
             $table->string('name');
             $table->string('email')->unique();

--- a/database/migrations/2014_10_12_100000_create_password_resets_table.php
+++ b/database/migrations/2014_10_12_100000_create_password_resets_table.php
@@ -14,6 +14,7 @@ class CreatePasswordResetsTable extends Migration
     public function up()
     {
         Schema::create('password_resets', function (Blueprint $table) {
+            $table->engine = 'InnoDB';
             $table->string('email')->index();
             $table->string('token')->index();
             $table->timestamp('created_at')->nullable();

--- a/database/migrations/2017_01_17_231217_create_activities_table.php
+++ b/database/migrations/2017_01_17_231217_create_activities_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateActivitiesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('activities', function (Blueprint $table) {
+            $table->engine = 'InnoDB';
+            $table->increments('id');
+            $table->integer('user_id')->unsigned();
+            $table->string('subject');
+            $table->timestamps();
+            $table->softDeletes();
+            $table->foreign('user_id')->references('id')->on('users');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('activities');
+    }
+}


### PR DESCRIPTION
Changes `users` and `password_resets` tables to InnoDB to allow for referencial integrity.

Adds a migration to create the `activities` table.

Fields include:
- `id` int(10) unsigned NOT NULL AUTO_INCREMENT
- `user_id` int(10) unsigned NOT NULL
- `subject` varchar(255) COLLATE utf8_unicode_ci NOT NULL
- `created_at` timestamp NULL DEFAULT NULL
- `updated_at` timestamp NULL DEFAULT NULL
- `deleted_at` timestamp NULL DEFAULT NULL

Primary key: `id`
Foreign key: `user_id` => `users`.`id`

Fixes #1 